### PR TITLE
Removed cssnano processor from first pass.

### DIFF
--- a/template/gulp/tasks/css.js
+++ b/template/gulp/tasks/css.js
@@ -12,8 +12,7 @@ gulp.task('css', () => {
 	const processors = [
 		inlineImports({ path: config.src }),
 		cssnext({ browsers: config.browsers }),
-		nested(),
-		cssnano({ autoprefixer: false })
+		nested()
 	];
 
 	return gulp


### PR DESCRIPTION
cssnano is applied to minify step only, should not be applied to first pass. Having a bundled but non-minified version is useful for human eyes.